### PR TITLE
Adding dist folder to README file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store


### PR DESCRIPTION
**dist** folder was missing from the README.
This commit is also my first commit which is done via merge request on github